### PR TITLE
Fix jwt auth issues

### DIFF
--- a/django_base/settings.py
+++ b/django_base/settings.py
@@ -95,6 +95,11 @@ REST_FRAMEWORK = {
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators
 REST_USE_JWT = True
 
+JWT_AUTH = {
+    'JWT_EXPIRATION_DELTA': datetime.timedelta(days=30),
+}
+
+
 AUTH_USER_MODEL = 'users.User'
 
 AUTH_PASSWORD_VALIDATORS = [


### PR DESCRIPTION
This pr adds a default authentication class that takes jwt into account and sets the jwt token expiration to 30 days

The frontend should send the following header `Authorization: JWT <token>`