### PR TITLE
Change versions of Django and urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ certifi==2019.3.9
 chardet==3.0.4
 defusedxml==0.5.0
 dj-database-url==0.5.0
-Django==2.2
+Django==2.2.8
 django-allauth==0.39.1
 django-cors-headers==3.0.2
 django-heroku==0.3.1
@@ -20,6 +20,6 @@ requests==2.21.0
 requests-oauthlib==1.2.0
 six==1.12.0
 sqlparse==0.3.0
-urllib3==1.24.1
+urllib3==1.24.2
 whitenoise==4.1.2
 django-debug-toolbar==2.0


### PR DESCRIPTION
## Description 📚 
- Changed version of `Django` according to [recommendations of security](https://www.djangoproject.com/weblog/2019/dec/02/security-releases/)
- Changed version of `urllib3` according to [recommendations of security](https://nvd.nist.gov/vuln/detail/CVE-2019-11324)